### PR TITLE
avoid -late- dom changes when dom is not present

### DIFF
--- a/etools-repeatable-field-set.html
+++ b/etools-repeatable-field-set.html
@@ -368,8 +368,11 @@ Custom property | Description | Default
         }
         children.forEach(function(child) {
           self.async(function() {
-            self.$$('#item-' + self._itemCounter).appendChild(child);
-            self._itemCounter += 1;
+            var currentItem = self.$$('#item-' + self._itemCounter);
+            if(currentItem) {
+            currentItem.appendChild(child);
+              self._itemCounter += 1;
+            }
           })
         });
       },


### PR DESCRIPTION
Sometimes this.async defer the dom modification to a moment where the dom is not present ( page changed or element removed ). this small fix avoid errors